### PR TITLE
Reproducibility Fix

### DIFF
--- a/exp_cifar/data_subset.py
+++ b/exp_cifar/data_subset.py
@@ -45,7 +45,7 @@ def load_cifar10_sub(args, target_probs=None, score=None, data_mask=None):
         subset_mask = stratified_sampling(torch.tensor(score), int(args.subset_rate * 50000))
         
     elif args.sample == 'beta':
-        subset_mask = beta_sampling(1-args.subset_rate, args.c_d, target_probs, data_mask, score)
+        subset_mask = beta_sampling(1-args.subset_rate, args.c_d, target_probs, score, data_mask)[0]
     else:
         subset_mask = data_mask[-int(args.subset_rate * len(data_mask)):]
         
@@ -97,7 +97,7 @@ def load_cifar100_sub(args, target_probs=None, score=None, data_mask=None):
         subset_mask = stratified_sampling(torch.tensor(score), int(args.subset_rate * 50000))
         
     elif args.sample == 'beta':
-        subset_mask = beta_sampling(1-args.subset_rate, args.c_d, target_probs, data_mask, score)
+        subset_mask = beta_sampling(1-args.subset_rate, args.c_d, target_probs, score, data_mask)[0]
     else:
         subset_mask = data_mask[-int(args.subset_rate * len(data_mask)):]
 
@@ -183,7 +183,7 @@ def beta_sampling(prune_rate, c_d, target_probs, score, mask):
     subset_n = int((1-prune_rate) * data_length)
     anchor_mean = pred_mean[mask[-10:]].mean()
     y_b = 15 * (1-anchor_mean) * (1 -prune_rate ** c_d)
-    y_a = 16 - y_b
+    y_a = 15 - y_b
     
     pdf_y = beta.pdf(pred_mean, y_a, y_b)
     joint_p = pdf_y * score

--- a/exp_cifar/train_subset.py
+++ b/exp_cifar/train_subset.py
@@ -58,7 +58,7 @@ parser.add_argument('--src-folder', help='train dynamics source')
 
 # Coreset Method
 parser.add_argument('--target-probs-path', default='./generated/cifar10/42/target_probs_win_10_ep200.npy', type=str, help='for dual + beta')
-parser.add_argument('--score-path', default='./generated/cifar10/42/dual_mask_T30.npy', type=str)
+parser.add_argument('--score-path', default='./generated/cifar10/42/dual_score_T30.npy', type=str)
 parser.add_argument('--mask-path', default='./generated/cifar10/42/dual_mask_T30.npy', type=str)
 parser.add_argument('--c_d', type=float, default=4, help='d_c for beta sampling')
 parser.add_argument('--key_T', type=int, default=30, help='score computation epoch')
@@ -103,7 +103,7 @@ def main(): #
     print_log("Momentum: {}".format(args.momentum), log)
     print_log("Weight Decay: {}".format(args.decay), log)
 
-    target_probs = np.load(args.target_probs_path)[:1]
+    target_probs = np.load(args.target_probs_path)
     score = np.load(args.score_path)
     mask = np.load(args.mask_path)
     


### PR DESCRIPTION
I found a few implementation mistakes in `beta_sampling` that leads to lower results than whats claimed in the paper. 

List of changes:
1. changed `target_probs` from  `np.load(args.target_probs_path)[:1]` to `target_probs = np.load(args.target_probs_path)`, taking into account all 200 of full-training epoch instead of just the first one.
2.  fixed the order of `mask` & `score` when calling `beta_sampling` and take the first output as `subset_mask`.
3. changed `C` from 16 to 15 `y_a`.

I conducted experiments under 3 pruning ratios on CIFAR10 & CIFAR100. Results are shown below.

#### CIFAR 100
| Data Source | Acc @ r=0.3  | Acc @ r=0.5  | Acc @ r=0.7  |
| - | - | - | - |
| Original Implementation | 75.3 | 70.5 | 56.2 |
| Fixed Implementation | 77.67 | 74.27 | 69.1 |
| Paper Claim | 77.86 | 74.66 | 69.25 |

#### CIFAR 10
| Data Source | Acc @ r=0.3  | Acc @ r=0.5  | Acc @ r=0.7  |
| - | - | - | - |
| Original Implementation | 94.8  | 93.4 | 88.4 |
| Fixed Implementation | 95.05 | 95.23 | 92.91 |
| Paper Claim | 95.51 | 95.23 | 93.04 |

Below are my commands to reproduce the results (CIFAR100, r=0.5):
> note that I modified `importance_evaluation.py` to set CIFAR dataset path to `/path/to/cifar/ds`
```
python train.py --dataset cifar100 --arch resnet18 --batch-size 128 --dynamics --save_path ./save/resnet18-full/42 --manualSeed 42 --gpu 0 --data_path /path/to/cifar/ds
python importance_evaluation.py --dynamics_path ./save/resnet18-full/42/cifar100/42/npy/ --dataset cifar100
python train_subset.py --data_path /path/to/cifar/ds --dataset cifar100 --target-probs-path ./generated/cifar100/42/target_probs_win_10_ep200.npy --score-path ./generated/cifar100/42/dual_score_T30.npy --mask-path ./generated/cifar100/42/dual_mask_T30.npy --subset_rate 0.5 --sample beta
```
